### PR TITLE
feat: m2m-rest-client

### DIFF
--- a/helm-templates/paas-mediation/templates/deployment.yaml
+++ b/helm-templates/paas-mediation/templates/deployment.yaml
@@ -58,9 +58,36 @@ spec:
               app.kubernetes.io/technology: 'go'
         spec:
             serviceAccountName: "{{ .Values.SERVICE_NAME }}"
+            volumes:
+              - name: projected-tokens
+                projected:
+                  defaultMode: 292
+                  sources:
+                    - serviceAccountToken:
+                        path: netcracker/token
+                        audience: netcracker
+                        expirationSeconds: 600
+                    - serviceAccountToken:
+                        path: dbaas/token
+                        audience: dbaas
+                        expirationSeconds: 600
+                    - serviceAccountToken:
+                        path: maas/token
+                        audience: maas
+                        expirationSeconds: 600
+              - name: topology
+                configMap:
+                  name: topology
             containers:
                 - name: "{{ .Values.SERVICE_NAME }}"
                   image: "{{ .Values.IMAGE_REPOSITORY }}:{{ .Values.TAG }}"
+                  volumeMounts:
+                    - name: projected-tokens
+                      mountPath: /var/run/secrets/tokens
+                      readOnly: true
+                    - name: topology
+                      mountPath: /etc/topology
+                      readOnly: true
                   args:
                       - '/app/paas-mediation'
                   ports:

--- a/helm-templates/paas-mediation/templates/deployment.yaml
+++ b/helm-templates/paas-mediation/templates/deployment.yaml
@@ -126,6 +126,8 @@ spec:
                         value: '{{ .Values.GATEWAY_SYSTEM_NAME }}'
                       - name: SERVICE_MESH_TYPE
                         value: '{{ .Values.SERVICE_MESH_TYPE }}'
+                      - name: KUBERNETES_M2M_ENABLED
+                        value: '{{ .Values.KUBERNETES_M2M_ENABLED }}'
                       - name: MEMORY_LIMIT
                         valueFrom:
                           resourceFieldRef:

--- a/helm-templates/paas-mediation/values.schema.json
+++ b/helm-templates/paas-mediation/values.schema.json
@@ -643,6 +643,14 @@
       "internal": true,
       "examples": ["gateway-system"],
       "description": "The value for spec.parentRefs.namespace of all Gateway API HttpRoute Custom Resources, that mean the namespace of where gateway controller is deployed."
+    },
+    "KUBERNETES_M2M_ENABLED": {
+      "$id": "#/properties/KUBERNETES_M2M_ENABLED",
+      "type": "boolean",
+      "title": "The KUBERNETES_M2M_ENABLED schema",
+      "description": "Shows that kubernetes m2m communication is enabled.",
+      "internal": true,
+      "default": false
     }
   },
   "additionalProperties": true

--- a/helm-templates/paas-mediation/values.yaml
+++ b/helm-templates/paas-mediation/values.yaml
@@ -33,3 +33,4 @@ K8S_SERVICE_TYPE: 'HEADLESS'
 ISTIO_PRIVATE_GATEWAY_NAME: 'private-gateway'
 INTERNAL_SERVICE_NAME: "internal-gateway-service"
 SERVICE_MESH_TYPE: 'Core' # Options: Core, Istio
+KUBERNETES_M2M_ENABLED: false


### PR DESCRIPTION
In facade-operator service use core-lib-go and rest-utils with k8s rest client