### PR TITLE
chore(deps): migrate junit-jupiter to 6.0.3

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,7 +22,20 @@
         <skipIT>true</skipIT>
         <cloud-core-extension.version>8.9.6</cloud-core-extension.version>
         <cloud.core.security.utils.version>3.1.8</cloud.core.security.utils.version>
+        <junit-bom.version>6.0.3</junit-bom.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <profiles>
         <profile>
@@ -80,7 +93,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.14.3</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Why

`integration-tests` pinned `junit-jupiter-engine` to 5.14.3 while depending on
`com.netcracker.cloud.junit.cloudcore:cloud-core-extension:8.9.6`, which is built against JUnit 6.0.3
(it imports `core-internal-bom:1.0.3`). Maven resolves the nearest declaration, so the local pin won and
the extension ran on a platform missing the APIs it was compiled against — a latent `NoSuchMethodError`
that the build does not catch.

The downgrade is visible in the dependency tree before this change:

```
org.junit.jupiter:junit-jupiter-engine:jar:5.14.3:test
  +- org.junit.platform:junit-platform-engine:jar:1.14.3:test
  |  \- org.junit.platform:junit-platform-commons:jar:1.14.3:test
  \- org.junit.jupiter:junit-jupiter-api:jar:5.14.3:test
```

## What

- Import `org.junit:junit-bom` (6.0.3, the latest 6.0.x) in `dependencyManagement`.
- Drop the literal `5.14.3` version from `junit-jupiter-engine` so the BOM keeps Jupiter and Platform
  aligned on future bumps. JUnit 6 unified the two version lines: `junit-platform-*` moved from `1.x` to `6.x`.

No test sources changed — all 53 test classes compile unmodified. The module uses none of the APIs JUnit 6
removed (`MethodOrderer.Alphanumeric`, `PreconditionViolationException`, `junit-platform-runner`,
`migrationsupport`, Vintage). Java is already 21, above the JUnit 6 baseline of 17, and
`maven-surefire-plugin` is 3.5.6, which discovers JUnit Platform 6.

## How to verify

```bash
mvn -B -ntp -f integration-tests/pom.xml dependency:tree -Dincludes=org.junit.jupiter:*,org.junit.platform:*
mvn -B -ntp -f integration-tests/pom.xml test-compile
```

Every `org.junit.*` coordinate resolves to 6.0.3, and `test-compile` succeeds. Integration tests themselves
are gated behind the `integration-test` profile and need a live environment, so they were not executed here.